### PR TITLE
Backend fetch from config

### DIFF
--- a/src/lib/useLoadLatestVerified.ts
+++ b/src/lib/useLoadLatestVerified.ts
@@ -1,25 +1,30 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { randomFromArray, backends } from "./useSubmitSources";
+import { randomFromArray, useBackends } from "./useSubmitSources";
 
 export function useLoadLatestVerified() {
+  const backends = useBackends();
   const backend = randomFromArray(backends);
 
-  const { isLoading, error, data } = useQuery(["latestVerifiedContracts"], async () => {
-    const response = await fetch(`${backend}/latestVerified`, {
-      method: "GET",
-    });
+  const { isLoading, error, data } = useQuery(
+    ["latestVerifiedContracts"],
+    async () => {
+      const response = await fetch(`${backend}/latestVerified`, {
+        method: "GET",
+      });
 
-    const latestVerified = (
-      (await response.json()) as {
-        address: string;
-        mainFile: string;
-        compiler: string;
-      }[]
-    ).slice(0, 100);
+      const latestVerified = (
+        (await response.json()) as {
+          address: string;
+          mainFile: string;
+          compiler: string;
+        }[]
+      ).slice(0, 100);
 
-    return latestVerified;
-  });
+      return latestVerified;
+    },
+    { enabled: backends.length > 0 },
+  );
 
   return { isLoading, error, data };
 }

--- a/src/lib/useOverride.ts
+++ b/src/lib/useOverride.ts
@@ -16,6 +16,11 @@ export function useOverride() {
     (async () => {
       if (!walletAddress || !contractAddress) return;
       if (urlParams.get("override") !== null) {
+        if (!!import.meta.env.VITE_OVERRIDE) {
+          setCanOverride(true);
+          return;
+        }
+
         const tc = await getClient();
         const admin = await getAdmin(Address.parse(window.sourcesRegistryAddress), tc);
         if (admin === walletAddress) {

--- a/src/lib/useRemoteConfig.ts
+++ b/src/lib/useRemoteConfig.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
-import { backends } from "./useSubmitSources";
 
 const configURL =
   "https://raw.githubusercontent.com/ton-community/contract-verifier-config/main/config.json";

--- a/src/lib/useRemoteConfig.ts
+++ b/src/lib/useRemoteConfig.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
+import { backends } from "./useSubmitSources";
 
 const configURL =
   "https://raw.githubusercontent.com/ton-community/contract-verifier-config/main/config.json";
@@ -10,16 +11,27 @@ export function useRemoteConfig() {
   return useQuery(
     ["remoteConfig"],
     async () => {
-      const { funcVersions, tactVersions, tolkVersions } = await (await fetch(configURL)).json();
+      const config: {
+        funcVersions: string[];
+        tactVersions: string[];
+        tolkVersions: string[];
+        backends: string[];
+        backendsTestnet: string[];
+      } = await (await fetch(configURL)).json();
 
       setEnabled(false);
 
-      return {
-        funcVersions: funcVersions as string[],
-        tactVersions: tactVersions as string[],
-        tolkVersions: tolkVersions as string[],
-      };
+      return config;
     },
-    { enabled, initialData: { funcVersions: [], tactVersions: [], tolkVersions: [] } },
+    {
+      enabled,
+      initialData: {
+        funcVersions: [],
+        tactVersions: [],
+        tolkVersions: [],
+        backends: [],
+        backendsTestnet: [],
+      },
+    },
   );
 }

--- a/src/lib/useSubmitSources.ts
+++ b/src/lib/useSubmitSources.ts
@@ -36,10 +36,6 @@ function jsonToBlob(json: Record<string, any>): Blob {
   });
 }
 
-// export const backends: string[] = window.isTestnet
-//   ? import.meta.env.VITE_BACKEND_URL_TESTNET!.split(",")
-//   : import.meta.env.VITE_BACKEND_URL_OVERRIDE!.split(",");
-
 const isTestnet = window.isTestnet;
 
 const useSubmitSourcesStatusStore = create<{


### PR DESCRIPTION
1. add support for VITE_OVERRIDE to override sources while running locally
2. read backends from https://github.com/ton-community/contract-verifier-config/blob/main/config.json 
3. enable overriding backend list with VITE_BACKEND_URL_OVERRIDE (for local development)